### PR TITLE
Add CIP export  to SDK

### DIFF
--- a/cip/index.ts
+++ b/cip/index.ts
@@ -36,16 +36,33 @@ export {
 
 // Export common graph module
 export {
+  newProjectEvent,
+  newTaskEvent,
+  newEntityEvent,
+  newRelationEvent,
+  newObservationEvent,
   toNostrEvent as toNostrEventCommonGraph
 } from './cip02/common_graph.js'
 
 // Export model graph module
 export {
+  newModelEvent,
+  newComputeEvent,
+  newAlgoEvent,
+  newValidEvent,
+  newDatasetEvent,
+  newFinetuneEvent,
+  newConversationEvent,
+  newSessionEvent,
   toNostrEvent as toNostrEventModelGraph
 } from './cip03/modelgraph.js'
 
 // Export community module
 export {
+  newCommunityCreateEvent,
+  newCommunityInviteEvent,
+  newChannelCreateEvent,
+  newChannelMessageEvent,
   toNostrEvent as toNostrEventCommunity
 } from './cip07/community.js'
 

--- a/cip/index.ts
+++ b/cip/index.ts
@@ -1,0 +1,56 @@
+// Export all CIP modules
+export {
+  newPaperEvent,
+  newAnnotationEvent,
+  newReviewEvent,
+  newAiAnalysisEvent,
+  newDiscussionEvent,
+  newReadPaperEvent,
+  newCoCreatePaperEvent,
+  toNostrEvent as toNostrEventOpenResearch
+} from './cip05/openresearch.js'
+
+export {
+  newLikeEvent,
+  newCollectEvent,
+  newShareEvent,
+  newCommentEvent,
+  newTagEvent,
+  newFollowEvent,
+  newUnfollowEvent,
+  newQuestionEvent,
+  newRoomEvent,
+  newMessageInRoomEvent,
+  toNostrEvent as toNostrEventSocial
+} from './cip06/social.js'
+
+// Export governance module
+export {
+  newPostEvent,
+  newProposeEvent,
+  newVoteEvent,
+  newInviteEvent,
+  newMintEvent,
+  toNostrEvent as toNostrEventGovernance
+} from './cip01/governance.js'
+
+// Export common graph module
+export {
+  toNostrEvent as toNostrEventCommonGraph
+} from './cip02/common_graph.js'
+
+// Export model graph module
+export {
+  toNostrEvent as toNostrEventModelGraph
+} from './cip03/modelgraph.js'
+
+// Export community module
+export {
+  toNostrEvent as toNostrEventCommunity
+} from './cip07/community.js'
+
+// Export core modules
+export * from './auth.js'
+export * from './constants.js'
+export * from './keys.js'
+export * from './subspace.js' 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,66 @@
       "require": "./lib/cjs/index.js",
       "types": "./lib/types/index.d.ts"
     },
+    "./cip": {
+      "import": "./lib/esm/cip/index.js",
+      "require": "./lib/cjs/cip/index.js",
+      "types": "./lib/types/cip/index.d.ts"
+    },
+    "./cip/social": {
+      "import": "./lib/esm/cip/cip06/social.js",
+      "require": "./lib/cjs/cip/cip06/social.js",
+      "types": "./lib/types/cip/cip06/social.d.ts"
+    },
+    "./cip/openresearch": {
+      "import": "./lib/esm/cip/cip05/openresearch.js",
+      "require": "./lib/cjs/cip/cip05/openresearch.js",
+      "types": "./lib/types/cip/cip05/openresearch.d.ts"
+    },
+    "./cip/governance": {
+      "import": "./lib/esm/cip/cip01/governance.js",
+      "require": "./lib/cjs/cip/cip01/governance.js",
+      "types": "./lib/types/cip/cip01/governance.d.ts"
+    },
+    "./cip/common-graph": {
+      "import": "./lib/esm/cip/cip02/common_graph.js",
+      "require": "./lib/cjs/cip/cip02/common_graph.js",
+      "types": "./lib/types/cip/cip02/common_graph.d.ts"
+    },
+    "./cip/model-graph": {
+      "import": "./lib/esm/cip/cip03/modelgraph.js",
+      "require": "./lib/cjs/cip/cip03/modelgraph.js",
+      "types": "./lib/types/cip/cip03/modelgraph.d.ts"
+    },
+    "./cip/key-token": {
+      "import": "./lib/esm/cip/cip04/keytoken.js",
+      "require": "./lib/cjs/cip/cip04/keytoken.js",
+      "types": "./lib/types/cip/cip04/keytoken.d.ts"
+    },
+    "./cip/community": {
+      "import": "./lib/esm/cip/cip07/community.js",
+      "require": "./lib/cjs/cip/cip07/community.js",
+      "types": "./lib/types/cip/cip07/community.d.ts"
+    },
+    "./cip/auth": {
+      "import": "./lib/esm/cip/auth.js",
+      "require": "./lib/cjs/cip/auth.js",
+      "types": "./lib/types/cip/auth.d.ts"
+    },
+    "./cip/constants": {
+      "import": "./lib/esm/cip/constants.js",
+      "require": "./lib/cjs/cip/constants.js",
+      "types": "./lib/types/cip/constants.d.ts"
+    },
+    "./cip/keys": {
+      "import": "./lib/esm/cip/keys.js",
+      "require": "./lib/cjs/cip/keys.js",
+      "types": "./lib/types/cip/keys.d.ts"
+    },
+    "./cip/subspace": {
+      "import": "./lib/esm/cip/subspace.js",
+      "require": "./lib/cjs/cip/subspace.js",
+      "types": "./lib/types/cip/subspace.d.ts"
+    },
     "./core": {
       "import": "./lib/esm/core.js",
       "require": "./lib/cjs/core.js",
@@ -237,6 +297,7 @@
     "@scure/base": "1.1.1",
     "@scure/bip32": "1.3.1",
     "@scure/bip39": "1.2.1",
+    "crelay-js-sdk": "link:../../.local/share/pnpm/global/5/node_modules/@ai-chen2050/crelay-js-sdk",
     "glob": "^11.0.2",
     "jest": "^29.7.0",
     "micro-eth-signer": "^0.14.0",
@@ -277,7 +338,9 @@
     "typescript": "^5.8.2"
   },
   "scripts": {
-    "prepublish": "just build"
+    "prepublish": "just build",
+    "build": "tsc && esbuild src/index.ts --bundle --outfile=lib/esm/index.js --format=esm && esbuild src/index.ts --bundle --outfile=lib/cjs/index.js --format=cjs",
+    "build:cip": "tsc && esbuild cip/index.ts --bundle --outfile=lib/esm/cip/index.js --format=esm && esbuild cip/index.ts --bundle --outfile=lib/cjs/cip/index.js --format=cjs"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Add CIP export  to SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a centralized module for easier access to multiple event creation and conversion utilities.
  - Added new export paths for various CIP-related modules, making them directly importable.
- **Chores**
  - Updated build scripts to support the new CIP modules.
  - Added a new dependency for extended SDK functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->